### PR TITLE
Починил отправку данных из processing/приложения

### DIFF
--- a/processing/GyverTwink/func.pde
+++ b/processing/GyverTwink/func.pde
@@ -32,7 +32,7 @@ void requestCfg() {
 
 void sendData(int[] data) {
   int[] buf = {'G', 'T'};
-  concat(buf, data);
+  buf = concat(buf, data);
   sendData(byte(buf));
 }
 


### PR DESCRIPTION
Старые версии работали (где были отдельные функции), а в универсальной была простая ошибка, из-за которой уходили только первые два байта (в гплее то же самое).